### PR TITLE
feat: resize column widgets

### DIFF
--- a/view/widgets/acquisition_widgets/channel_plan_widget.py
+++ b/view/widgets/acquisition_widgets/channel_plan_widget.py
@@ -234,6 +234,7 @@ class ChannelPlanWidget(QTabWidget):
             table.setItem(table_row, table.columnCount() - 1, item)
             for column, array in enumerate(arrays):
                 item = QTableWidgetItem()
+                item.setTextAlignment(Qt.AlignHCenter)  # change the alignment
                 if type(delegates[column]) == QSpinItemDelegate:
                     item.setData(Qt.EditRole, float(array[*tile]))
                 else:

--- a/view/widgets/acquisition_widgets/volume_widget.py
+++ b/view/widgets/acquisition_widgets/volume_widget.py
@@ -219,6 +219,7 @@ class VolumeWidget(QWidget):
 
         if not self.anchor_widgets[2].isChecked():  # disable start widget for any new widgets
             self.disable_scan_start_widgets(True)
+        self.table.resizeColumnsToContents()
 
     def channel_added(self, channel):
         """Update new channel with tiles"""
@@ -241,6 +242,7 @@ class VolumeWidget(QWidget):
         items = {}
         for header_col, header in enumerate(self.columns):
             item = QTableWidgetItem()
+            item.setTextAlignment(Qt.AlignHCenter)  # change the alignment
             if header == 'row, column':
                 item.setText(str(kwargs[header]))
             else:


### PR DESCRIPTION
fixes #36 
- center items in horizontally in table
- resize table to fit contents after tiles are added 