### PR TITLE
Feat change volume model color

### DIFF
--- a/examples/volume_widget_example.py
+++ b/examples/volume_widget_example.py
@@ -5,20 +5,10 @@ from unittest.mock import MagicMock
 from pathlib import Path
 import os
 from voxel.devices.lasers.simulated import SimulatedLaser
+from voxel.devices.stage.simulated import Stage
 from view.widgets.device_widgets.laser_widget import LaserWidget
 from threading import Lock
 from qtpy.QtCore import Qt
-
-RESOURCES_DIR = (
-        Path(os.path.dirname(os.path.realpath(__file__))) / "resources"
-)
-INSTRUMENT_YAML = RESOURCES_DIR / 'simulated_instrument.yaml'
-
-
-class MockInstrument:
-    def __init__(self, **kwds):
-        for key, value in kwds.items():
-            setattr(self, key, value)
 
 
 if __name__ == "__main__":
@@ -45,6 +35,15 @@ if __name__ == "__main__":
         '639nm': SimulatedLaser(id='there')
     }
 
+    tiling_stages = {
+        'x': Stage(hardware_axis='x', instrument_axis='x'),
+        'y': Stage(hardware_axis='y', instrument_axis='y')
+    }
+
+    scanning_stages = {
+        'z': Stage(hardware_axis='z', instrument_axis='z')
+    }
+
     laser_widgets = {
         '488nm': LaserWidget(lasers['488nm']),
         '639nm': LaserWidget(lasers['639nm'])
@@ -56,7 +55,7 @@ if __name__ == "__main__":
     }
 
     mocked_instrument = MagicMock()
-    mocked_instrument.configure_mock(lasers=lasers)
+    mocked_instrument.configure_mock(lasers=lasers, tiling_stages=tiling_stages, scanning_stages=scanning_stages)
     mocked_instrument_view = MagicMock()
     mocked_instrument_view.configure_mock(instrument=mocked_instrument, laser_widgets=laser_widgets, laser_widget_locks=laser_widget_locks)
     volume_widget = VolumeWidget(mocked_instrument_view, channels, settings)

--- a/view/widgets/acquisition_widgets/volume_model.py
+++ b/view/widgets/acquisition_widgets/volume_model.py
@@ -46,17 +46,20 @@ class VolumeModel(GLOrthoViewWidget):
                  limits: list[float] = None,
                  fov_color: str = 'yellow',
                  fov_line_width: int = 2,
-                 fov_opacity: float = .15,
+                 fov_opacity: float = 0.15,
                  path_line_width: int = 2,
                  path_arrow_size: float = 6.0,
                  path_arrow_aspect_ratio: int = 4,
                  path_start_color: str = 'magenta',
                  path_end_color: str = 'green',
-                 tile_color: str = 'cyan',
-                 tile_opacity: float = .075,
+                 active_tile_color: str = 'cyan',
+                 active_tile_opacity: float = 0.075,
+                 inactive_tile_color: str = 'red',
+                 inactive_tile_opacity: float = 0.025,
                  tile_line_width: int = 2,
                  limits_line_width: int = 2,
-                 limits_color: str = 'white'):
+                 limits_color: str = 'white',
+                 limits_opacity: float = 0.01):
 
         """
         GLViewWidget to display proposed grid of acquisition
@@ -74,14 +77,18 @@ class VolumeModel(GLOrthoViewWidget):
         :param path_arrow_aspect_ratio: aspect ratio of arrow
         :param path_start_color: start color of path
         :param path_end_color: end color of path
-        :param tile_color: color of tiles
-        :param tile_opacity: opacity of tile faces where 1 is fully opaque
+        :param active_tile_color: color of tiles when fov is within tile grid
+        :param active_tile_opacity: opacity of active tile grid faces where 1 is fully opaque
+        :param inactive_tile_color: color of tiles when fov is outside of tile grid
+        :param inactive_tile_opacity: opacity of inactive tile grid faces where 1 is fully opaque
         :param tile_line_width: width of tiles
         :param limits_line_width: width of limits box
         :param limits_color: color of limits box
+        :param limits_opacity: opacity of limits box
         """
 
         super().__init__(rotationMethod='quaternion')
+        limits = [[-2, 2], [-2, 2], [-2, 2]]
         self.makeCurrent()
         self.unit = unit
         self.coordinate_plane = [x.replace('-', '') for x in coordinate_plane]
@@ -99,9 +106,15 @@ class VolumeModel(GLOrthoViewWidget):
         self.grid_tile_items = []  # list of 2D lists detailing face items in grid
         self.tile_visibility = np.array([[True]])  # 2d list detailing visibility of tiles
         # tile aesthetic properties
-        self.tile_color = tile_color
-        self.tile_opacity = tile_opacity
+        self.active_tile_color = active_tile_color
+        self.active_tile_opacity = active_tile_opacity
+        self.inactive_tile_color = inactive_tile_color
+        self.inactive_tile_opacity = inactive_tile_opacity
         self.tile_line_width = tile_line_width
+        # limits aesthetic properties
+        self.limits_line_width = limits_line_width
+        self.limits_color = limits_color
+        self.limits_opacity = limits_opacity
 
         # position data set externally since tiles are assumed out of order
         self.path = GLPathItem(width=path_line_width,
@@ -132,12 +145,23 @@ class VolumeModel(GLOrthoViewWidget):
         self.addItem(self.fov_view_face)
 
         size = [((max(limits[i])-min(limits[i]))+fov_dimensions[i]) for i in range(3)]
-        stage_limits = GLBoxItem(color='white')
-        stage_limits.setSize(x=size[0], y=size[1], z=size[2])
-        stage_limits.setTransform(QMatrix4x4(1, 0, 0,  min([x*self.polarity[0] for x in limits[0]]),
-                                              0, 1, 0, min([y*self.polarity[1] for y in limits[1]]),
-                                              0, 0, 1, min([z*self.polarity[2] for z in limits[2]]),
-                                              0, 0, 0, 1))
+
+        stage_tile = GLTileItem(width=self.limits_line_width)
+        stage_tile.setColor(self.limits_color)
+        stage_tile.setSize(*size)
+        stage_tile.setTransform(QMatrix4x4(1, 0, 0, min([x*self.polarity[0] for x in limits[0]]),
+                                           0, 1, 0, min([y*self.polarity[1] for y in limits[1]]),
+                                           0, 0, 1, min([z*self.polarity[2] for z in limits[2]]),
+                                           0, 0, 0, 1))
+        self.addItem(stage_tile)
+
+        stage_limits = GLShadedBoxItem(pos=np.array([[[min([x*self.polarity[0] for x in limits[0]]),
+                                                      min([y*self.polarity[1] for y in limits[1]]),
+                                                      min([z*self.polarity[2] for z in limits[2]])]]]),
+                                       size=np.array(size),
+                                       color=self.limits_color,
+                                       opacity=self.limits_opacity,
+                                       glOptions='additive')
         self.addItem(stage_limits)
 
         self.valueChanged[str].connect(self.update_model)
@@ -190,25 +214,25 @@ class VolumeModel(GLOrthoViewWidget):
                     tile = GLTileItem(width=self.tile_line_width)
                     tile.setSize(*size)
                     tile.setTransform(QMatrix4x4(1, 0, 0, coord[0],
-                                                0, 1, 0, coord[1],
-                                                0, 0, 1, coord[2],
-                                                0, 0, 0, 1))
-                    tile.setColor(self.tile_color)
+                                                 0, 1, 0, coord[1],
+                                                 0, 0, 1, coord[2],
+                                                 0, 0, 0, 1))
+                    tile.setColor(self.active_tile_color)
                     tile.setVisible(self.tile_visibility[row, column])
                     self.addItem(tile)
                     self.grid_tile_items.append(tile)
 
                     # scale opacity for viewing
                     if self.view_plane == (self.coordinate_plane[0], self.coordinate_plane[1]):
-                        opacity = self.tile_opacity
+                        opacity = self.active_tile_opacity
                     elif self.view_plane == (self.coordinate_plane[2], self.coordinate_plane[1]):
-                        opacity = self.tile_opacity/total_columns
+                        opacity = self.active_tile_opacity/total_columns
                     else:
-                        opacity = self.tile_opacity / total_rows
+                        opacity = self.active_tile_opacity / total_rows
 
                     box = GLShadedBoxItem(pos=np.array([[coord]]),
                                           size=np.array(size),
-                                          color=self.tile_color,
+                                          color=self.active_tile_color,
                                           opacity=opacity,
                                           glOptions='additive',
                                           )
@@ -287,6 +311,7 @@ class VolumeModel(GLOrthoViewWidget):
         view_pol = [self.polarity[self.coordinate_plane.index(view_plane[0])],
                     self.polarity[self.coordinate_plane.index(view_plane[1])]]
         coords = self.grid_coords.reshape([-1, 3])  # flatten array
+        dimensions = self.scan_volumes.flatten()  # flatten array
 
         # set rotation
         root = sqrt(2.0) / 2.0
@@ -296,7 +321,6 @@ class VolumeModel(GLOrthoViewWidget):
             self.opts['rotation'] = QQuaternion(-root, 0, -root, 0) if \
                 view_plane == (self.coordinate_plane[2], self.coordinate_plane[1]) else QQuaternion(-root, root, 0, 0)
             # take into account end of tile and account for difference in size if z included in view
-            dimensions = self.scan_volumes.flatten()  # flatten array
             coords = np.concatenate((coords, [[x,
                                                y,
                                                (z + sz)] for (x, y, z), sz in zip(coords, dimensions)]))
@@ -304,9 +328,9 @@ class VolumeModel(GLOrthoViewWidget):
         extrema = {'x_min': min([x for x, y, z in coords]), 'x_max': max([x for x, y, z in coords]),
                    'y_min': min([y for x, y, z in coords]), 'y_max': max([y for x, y, z in coords]),
                    'z_min': min([z for x, y, z in coords]), 'z_max': max([z for x, y, z in coords])}
-
         fov = {**{axis: dim for axis, dim in zip(['x', 'y'], self.fov_dimensions)}, 'z': 0}
         pos = {axis: dim for axis, dim in zip(['x', 'y', 'z'], self.fov_position)}
+
         distances = {'xy': [sqrt((pos[view_plane[0]] - x) ** 2 + (pos[view_plane[1]] - y) ** 2) for x, y, z in coords],
                      'xz': [sqrt((pos[view_plane[0]] - x) ** 2 + (pos[view_plane[1]] - z) ** 2) for x, y, z in coords],
                      'zy': [sqrt((pos[view_plane[0]] - z) ** 2 + (pos[view_plane[1]] - y) ** 2) for x, y, z in coords]}
@@ -346,6 +370,25 @@ class VolumeModel(GLOrthoViewWidget):
             center.get('x', 0),
             center.get('y', 0),
             center.get('z', 0))
+
+        # update color of tiles based on z position
+        absolute_coords = np.concatenate((coords, [[x, y, (z + sz)] for
+                                         (x, y, z), sz in zip(coords, dimensions)]))
+        x_min = min(absolute_coords[:, 0])  # min x value of tiles
+        x_max = max(absolute_coords[:, 0])  # max x value of tiles
+        y_min = min(absolute_coords[:, 1])  # min y value of tiles
+        y_max = max(absolute_coords[:, 1])  # max y value of tiles
+        z_min = min(absolute_coords[:, 2])  # min z value of tiles
+        z_max = max(absolute_coords[:, 2])  # max z value of tiles
+
+        for box, tile in zip(self.grid_box_items, self.grid_tile_items):
+            # recolor box if fov position outside range of tiles
+            if self.fov_position[2] > z_max or self.fov_position[2] < z_min or \
+               self.fov_position[1] > y_max or self.fov_position[1] < y_min or \
+               self.fov_position[0] > x_max or self.fov_position[0] < x_min:
+                tile.setColor(self.inactive_tile_color)
+                box.updateColor(color=self.inactive_tile_color, opacity=self.inactive_tile_opacity)
+
         self.update()
 
     def move_fov_query(self, new_fov_pos):
@@ -424,7 +467,7 @@ class VolumeModel(GLOrthoViewWidget):
                     distance, index = tree.query([new_pos['x'], new_pos['y'], new_pos['z']])
                     tile = flattened[index]
                     pos = {'x': tile[0], 'y': tile[1], 'z': tile[2]}
-                #self.fov_position = [pos['x'], pos['y'], pos['z']]
+                self.fov_position = [pos['x'], pos['y'], pos['z']]
                 self.view_plane = plane  # make sure grid plane remains the same
                 self.fovMoved.emit([pos['x'], pos['y'], pos['z']])
 

--- a/view/widgets/acquisition_widgets/volume_widget.py
+++ b/view/widgets/acquisition_widgets/volume_widget.py
@@ -1,5 +1,5 @@
 from qtpy.QtWidgets import QWidget, QCheckBox, QHBoxLayout, QLabel, QButtonGroup, QRadioButton, \
-    QGridLayout, QTableWidgetItem, QTableWidget, QSplitter, QFrame, QStyle, QPushButton, QVBoxLayout
+    QGridLayout, QTableWidgetItem, QTableWidget, QSplitter, QFrame
 from view.widgets.miscellaneous_widgets.q_item_delegates import QSpinItemDelegate
 from view.widgets.acquisition_widgets.scan_plan_widget import ScanPlanWidget
 from view.widgets.acquisition_widgets.volume_model import VolumeModel
@@ -10,8 +10,6 @@ from qtpy.QtCore import Qt
 import numpy as np
 import useq
 from view.widgets.base_device_widget import label_maker
-import inspect
-
 
 class VolumeWidget(QWidget):
     """Widget to combine scanning, tiling, channel, and model together to ease acquisition setup"""

--- a/view/widgets/miscellaneous_widgets/gl_shaded_box_item.py
+++ b/view/widgets/miscellaneous_widgets/gl_shaded_box_item.py
@@ -27,16 +27,21 @@ class GLShadedBoxItem(GLMeshItem):
             [1, 3, 5], [7, 5, 3]]).reshape(1, 12, 3)
         size = size.reshape((nCubes, 1, 3))
         pos = pos.reshape((nCubes, 1, 3))
-        vertexes = (cubeVerts * size + pos)[0]
-        faces = (cubeFaces + (np.arange(nCubes) * 8).reshape(nCubes, 1, 1))[0]
-
+        self._vertexes = (cubeVerts * size + pos)[0]
+        self._faces = (cubeFaces + (np.arange(nCubes) * 8).reshape(nCubes, 1, 1))[0]
         if isinstance(color, str):
             rgbf = list(QColor(color).getRgbF())
             color = rgbf[:3] + [opacity*rgbf[3]]
 
         colors = np.array([color for i in range(12)])
 
-        super().__init__(vertexes=vertexes, faces=faces, faceColors=colors,
+        super().__init__(vertexes=self._vertexes, faces=self._faces, faceColors=colors,
                      drawEdges=True, edgeColor=(0, 0, 0, 1), glOptions=glOptions, parentItem=parentItem)
 
+    def updateColor(self, color=None, opacity=1):
+        if isinstance(color, str):
+            rgbf = list(QColor(color).getRgbF())
+            color = rgbf[:3] + [opacity*rgbf[3]]
+        colors = np.array([color for i in range(12)])
+        self.setMeshData(vertexes=self._vertexes, faces=self._faces, faceColors=colors)
 

--- a/view/widgets/miscellaneous_widgets/gl_shaded_box_item.py
+++ b/view/widgets/miscellaneous_widgets/gl_shaded_box_item.py
@@ -1,12 +1,12 @@
 from pyqtgraph.opengl import GLMeshItem
 import numpy as np
 from qtpy.QtGui import QColor
-
+from OpenGL.GL import *  # noqa
 
 class GLShadedBoxItem(GLMeshItem):
     """Subclass of GLMeshItem creates a rectangular mesh item"""
 
-    def __init__(self, pos=None, size=None, color =None, opacity= 1, glOptions=None, parentItem=None):
+    def __init__(self, pos, size, color='cyan', width=1, opacity= 1, glOptions=None, parentItem=None):
         """
 
         :param pos: position of ite,
@@ -15,6 +15,21 @@ class GLShadedBoxItem(GLMeshItem):
         :param glOptions:
         :param parentItem:
         """
+
+        self._size = size
+        self._width = width
+        self._opacity = opacity
+        self._color = color
+        colors = np.array([self._convert_color(color) for i in range(12)])
+
+        self._pos = pos
+        self._vertexes, self._faces = self._create_box(pos, size)
+
+        super().__init__(vertexes=self._vertexes, faces=self._faces, faceColors=colors,
+                     drawEdges=True, edgeColor=(0, 0, 0, 1), glOptions=glOptions, parentItem=parentItem)
+
+    def _create_box(self, pos, size):
+        """Convenience method create the vertexes and faces of box to draw"""
 
         nCubes = np.prod(pos.shape[:-1])
         cubeVerts = np.mgrid[0:2, 0:2, 0:2].reshape(3, 8).transpose().reshape(1, 8, 3)
@@ -27,21 +42,76 @@ class GLShadedBoxItem(GLMeshItem):
             [1, 3, 5], [7, 5, 3]]).reshape(1, 12, 3)
         size = size.reshape((nCubes, 1, 3))
         pos = pos.reshape((nCubes, 1, 3))
-        self._vertexes = (cubeVerts * size + pos)[0]
-        self._faces = (cubeFaces + (np.arange(nCubes) * 8).reshape(nCubes, 1, 1))[0]
-        if isinstance(color, str):
-            rgbf = list(QColor(color).getRgbF())
-            color = rgbf[:3] + [opacity*rgbf[3]]
+        vertexes = (cubeVerts * size + pos)[0]
+        faces = (cubeFaces + (np.arange(nCubes) * 8).reshape(nCubes, 1, 1))[0]
 
-        colors = np.array([color for i in range(12)])
+        return vertexes, faces
 
-        super().__init__(vertexes=self._vertexes, faces=self._faces, faceColors=colors,
-                     drawEdges=True, edgeColor=(0, 0, 0, 1), glOptions=glOptions, parentItem=parentItem)
+    def color(self):
+        """Color of box and outline"""
+        return self._color
 
-    def updateColor(self, color=None, opacity=1):
-        if isinstance(color, str):
-            rgbf = list(QColor(color).getRgbF())
-            color = rgbf[:3] + [opacity*rgbf[3]]
-        colors = np.array([color for i in range(12)])
+    def setColor(self, color: str or list):
+        self._color = color
+        colors = np.array([self._convert_color(self._color) for i in range(12)])
         self.setMeshData(vertexes=self._vertexes, faces=self._faces, faceColors=colors)
 
+    def _convert_color(self, color):
+        """Convenience method used to convert string color"""
+        if isinstance(color, str):
+            rgbf = list(QColor(color).getRgbF())
+            color = rgbf[:3] + [self._opacity*rgbf[3]]
+        return color
+    def size(self):
+        """Size of box and outline"""
+        return self._size
+    def setSize(self, x, y, z):
+        self._size = np.array([x,y,z])
+        self._vertexes, self._faces = self._create_box(self._pos, self._size)
+        colors = np.array([self._convert_color(self._color) for i in range(12)])
+        self.setMeshData(vertexes=self._vertexes,
+                         faces=self._faces,
+                         faceColors=colors)
+    def paint(self):
+        """Overwriting to include box outline"""
+
+        super().paint()
+
+        self.setupGLState()
+        glLineWidth(self._width)  # added line for thickness setting
+
+        glBegin(GL_LINES)
+
+        glColor4f(*self._convert_color(self._color))
+
+        x, y, z = [self._pos[0,0,i]+x for i, x in enumerate(self.size())]
+        x_pos, y_pos, z_pos = self._pos[0,0,:]
+
+        glVertex3f(x_pos, y_pos, z_pos)
+        glVertex3f(x_pos, y_pos, z)
+        glVertex3f(x, y_pos, z_pos)
+        glVertex3f(x, y_pos, z)
+        glVertex3f(x_pos, y, z_pos)
+        glVertex3f(x_pos, y, z)
+        glVertex3f(x, y, z_pos)
+        glVertex3f(x, y, z)
+
+        glVertex3f(x_pos, y_pos, z_pos)
+        glVertex3f(x_pos, y, z_pos)
+        glVertex3f(x, y_pos, z_pos)
+        glVertex3f(x, y, z_pos)
+        glVertex3f(x_pos, y_pos, z)
+        glVertex3f(x_pos, y, z)
+        glVertex3f(x, y_pos, z)
+        glVertex3f(x, y, z)
+
+        glVertex3f(x_pos, y_pos, z_pos)
+        glVertex3f(x, y_pos, z_pos)
+        glVertex3f(x_pos, y, z_pos)
+        glVertex3f(x, y, z_pos)
+        glVertex3f(x_pos, y_pos, z)
+        glVertex3f(x, y_pos, z)
+        glVertex3f(x_pos, y, z)
+        glVertex3f(x, y, z)
+
+        glEnd()


### PR DESCRIPTION
Adding functionality to change tile grid color when FOV location wanders outside of the tile grid boundary.

- [x] Added init args to control active/inactive visualization of the tile grid
- [x] Added logic into the ```update_opts``` function to toggle the grid color. https://github.com/AllenNeuralDynamics/view/blob/f984035140b22ed9414ea1c2a95a8c8b543e665e/view/widgets/acquisition_widgets/volume_model.py#L374-L390
- [x] Update process calls ```setColor``` to update the color of the wireframe box. The shaded box has no such function, so added an ```updateColor``` function to achieve this behavior. https://github.com/AllenNeuralDynamics/view/blob/f984035140b22ed9414ea1c2a95a8c8b543e665e/view/widgets/miscellaneous_widgets/gl_shaded_box_item.py#L41-L46