### PR TITLE
Add acquisition defaults

### DIFF
--- a/src/view/widgets/acquisition_widgets/channel_plan_widget.py
+++ b/src/view/widgets/acquisition_widgets/channel_plan_widget.py
@@ -9,6 +9,8 @@ from inflection import singularize
 from math import isnan
 import pint
 import inspect
+
+
 class ChannelPlanWidget(QTabWidget):
     """Widget defining parameters per tile per channel """
 
@@ -30,7 +32,6 @@ class ChannelPlanWidget(QTabWidget):
         self.properties = properties
         self.default_prefix = properties['default_prefix'] if 'default_prefix' in properties.keys() else ''
         self.default_step_size = properties['default_step_size'] if 'default_step_size' in properties.keys() else 0.0
-
         self.column_data_types = {'step size [um]': float, 'steps': int, 'prefix': str}
 
         # setup units for step size and step calculation
@@ -423,6 +424,7 @@ class ChannelPlanWidget(QTabWidget):
             step_size = 0
         self.step_size[channel][*index] = step_size
         return step_size, steps
+
 
 class ChannelPlanTabBar(QTabBar):
     """TabBar that will keep add channel tab at end"""

--- a/src/view/widgets/acquisition_widgets/channel_plan_widget.py
+++ b/src/view/widgets/acquisition_widgets/channel_plan_widget.py
@@ -28,6 +28,9 @@ class ChannelPlanWidget(QTabWidget):
         self.possible_channels = channels
         self.channels = []
         self.properties = properties
+        self.default_prefix = properties['default_prefix'] if 'default_prefix' in properties.keys() else ''
+        self.default_step_size = properties['default_step_size'] if 'default_step_size' in properties.keys() else 0.0
+
         self.column_data_types = {'step size [um]': float, 'steps': int, 'prefix': str}
 
         # setup units for step size and step calculation
@@ -252,7 +255,9 @@ class ChannelPlanWidget(QTabWidget):
 
         self.steps[channel] = np.zeros(self._tile_volumes.shape, dtype=int)
         self.step_size[channel] = np.zeros(self._tile_volumes.shape, dtype=float)
+        self.step_size[channel][:, :] = self.default_step_size
         self.prefix[channel] = np.zeros(self._tile_volumes.shape, dtype='U100')
+        self.prefix[channel][:,:] = self.default_prefix
 
         self.insertTab(0, table, channel)
         self.setCurrentIndex(0)

--- a/src/view/widgets/acquisition_widgets/volume_model.py
+++ b/src/view/widgets/acquisition_widgets/volume_model.py
@@ -306,26 +306,31 @@ class VolumeModel(GLOrthoViewWidget):
                     size = [*self.fov_dimensions[:2], self.scan_volumes[row, column]]
 
                     # determine color
-                    if coord[0] < center_line and in_grid:
-                        color = self.active_tile_color
-                        opacity = self.active_tile_opacity
-                    elif coord[0] >= center_line and in_grid:
-                        if self.dual_sided:
-                            color = self.dual_active_tile_color
-                            opacity = self.dual_active_tile_opacity
-                        else:
-                            color = self.active_tile_color
-                            opacity = self.active_tile_opacity
+                    if in_grid:
+                        color = self.active_tile_color if coord[0] < center_line or not self.dual_sided else self.dual_active_tile_color
+                        opacity = self.active_tile_opacity if coord[0] < center_line or not self.dual_sided else self.dual_active_tile_opacity
                     else:
                         color = self.inactive_tile_color
                         opacity = self.inactive_tile_opacity
 
+                    # if coord[0] < center_line and in_grid:
+                    #     color = self.active_tile_color
+                    #     opacity = self.active_tile_opacity
+                    # elif coord[0] >= center_line and in_grid:
+                    #     if self.dual_sided:
+                    #         color = self.dual_active_tile_color
+                    #         opacity = self.dual_active_tile_opacity
+                    #     else:
+                    #         color = self.active_tile_color
+                    #         opacity = self.active_tile_opacity
+                    # else:
+                    #     color = self.inactive_tile_color
+                    #     opacity = self.inactive_tile_opacity
+
                     # scale opacity for viewing
-                    if self.view_plane == (self.coordinate_plane[0], self.coordinate_plane[1]):
-                        opacity = opacity
-                    elif self.view_plane == (self.coordinate_plane[2], self.coordinate_plane[1]):
+                    if self.view_plane == (self.coordinate_plane[2], self.coordinate_plane[1]):
                         opacity = opacity / total_columns
-                    else:
+                    elif self.view_plane != (self.coordinate_plane[0], self.coordinate_plane[1]):
                         opacity = opacity / total_rows
 
                     box = GLShadedBoxItem(

--- a/src/view/widgets/acquisition_widgets/volume_model.py
+++ b/src/view/widgets/acquisition_widgets/volume_model.py
@@ -51,16 +51,19 @@ class VolumeModel(GLOrthoViewWidget):
         path_line_width: int = 2,
         path_arrow_size: float = 6.0,
         path_arrow_aspect_ratio: int = 4,
-        path_start_color: str = "magenta",
+        path_start_color: str = "yellow",
         path_end_color: str = "green",
         active_tile_color: str = "cyan",
         active_tile_opacity: float = 0.075,
+        dual_active_tile_color: str = "magenta",
+        dual_active_tile_opacity: float = 0.075,
         inactive_tile_color: str = "red",
         inactive_tile_opacity: float = 0.025,
         tile_line_width: int = 2,
         limits_line_width: int = 2,
         limits_color: str = "white",
         limits_opacity: float = 0.1,
+        dual_sided: bool = True,
     ):
         """
         GLViewWidget to display proposed grid of acquisition
@@ -106,8 +109,11 @@ class VolumeModel(GLOrthoViewWidget):
         self.tile_visibility = np.array([[True]])  # 2d list detailing visibility of tiles
 
         # tile aesthetic properties
+        self.dual_sided = dual_sided
         self.active_tile_color = active_tile_color
         self.active_tile_opacity = active_tile_opacity
+        self.dual_active_tile_color = dual_active_tile_color
+        self.dual_active_tile_opacity = dual_active_tile_opacity
         self.inactive_tile_color = inactive_tile_color
         self.inactive_tile_opacity = inactive_tile_opacity
         self.tile_line_width = tile_line_width
@@ -290,25 +296,43 @@ class VolumeModel(GLOrthoViewWidget):
             total_rows = len(self.grid_coords)
             total_columns = len(self.grid_coords[0])
 
+            # determine middle x coordinate
+            center_line = np.mean(coords[:, 0])
+
             for row in range(total_rows):
                 for column in range(total_columns):
 
                     coord = [x * pol for x, pol in zip(self.grid_coords[row][column], self.polarity)]
                     size = [*self.fov_dimensions[:2], self.scan_volumes[row, column]]
 
+                    # determine color
+                    if coord[0] < center_line and in_grid:
+                        color = self.active_tile_color
+                        opacity = self.active_tile_opacity
+                    elif coord[0] >= center_line and in_grid:
+                        if self.dual_sided:
+                            color = self.dual_active_tile_color
+                            opacity = self.dual_active_tile_opacity
+                        else:
+                            color = self.active_tile_color
+                            opacity = self.active_tile_opacity
+                    else:
+                        color = self.inactive_tile_color
+                        opacity = self.inactive_tile_opacity
+
                     # scale opacity for viewing
                     if self.view_plane == (self.coordinate_plane[0], self.coordinate_plane[1]):
-                        opacity = self.active_tile_opacity
+                        opacity = opacity
                     elif self.view_plane == (self.coordinate_plane[2], self.coordinate_plane[1]):
-                        opacity = self.active_tile_opacity / total_columns
+                        opacity = opacity / total_columns
                     else:
-                        opacity = self.active_tile_opacity / total_rows
+                        opacity = opacity / total_rows
 
                     box = GLShadedBoxItem(
                         width=self.tile_line_width,
                         pos=np.array([[coord]]),
                         size=np.array(size),
-                        color=self.active_tile_color if in_grid else self.inactive_tile_color,
+                        color=color,
                         opacity=opacity,
                         glOptions="additive",
                     )


### PR DESCRIPTION
- added defaults for step/prefix in channel plan widget
- added defaults for overlap and tile order in volume plan widget
- added an init arg for "dual-sided" in volume model that will optionally color the left/right tiles differently

Let me know your thoughts and if you would rather not merge any of these additions? Most of the view GUI changes I have subclassed and put in exaspim-control. But for these I think it would be overkill to subclass all three widgets but we can totally do that too.